### PR TITLE
feat: implement TCP socket server for low-latency TOTP requests

### DIFF
--- a/examples/socket_client.py
+++ b/examples/socket_client.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Example client for YubiKey Daemon TCP Socket Server.
+
+This script demonstrates how to interact with the TCP socket server
+using the simple line-based protocol to retrieve TOTP codes.
+
+Protocol:
+- Commands end with '\\n'
+- Responses: 'OK <data>\\n' or 'ERROR <message>\\n'
+- Commands:
+  - GET_TOTP\\n → OK 123456\\n (returns first account's TOTP)
+  - GET_TOTP <account>\\n → OK 123456\\n (returns specific account's TOTP)
+  - LIST_ACCOUNTS\\n → OK GitHub,AWS,Google\\n (returns comma-separated list)
+
+Usage:
+    python examples/socket_client.py [--host HOST] [--port PORT] [--account ACCOUNT]
+"""
+
+import argparse
+import socket
+import sys
+
+
+def send_command(host: str, port: int, command: str, timeout: float = 30.0) -> str:
+    """Send a command to the socket server and receive response.
+
+    Args:
+        host: Server host
+        port: Server port
+        command: Command to send (without trailing newline)
+        timeout: Socket timeout in seconds
+
+    Returns:
+        Response string (without trailing newline)
+
+    Raises:
+        ConnectionError: If unable to connect to server
+        socket.timeout: If operation times out
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:
+            client_socket.settimeout(timeout)
+            client_socket.connect((host, port))
+            client_socket.sendall((command + "\n").encode("utf-8"))
+
+            # Receive response
+            response = b""
+            while b"\n" not in response:
+                chunk = client_socket.recv(1024)
+                if not chunk:
+                    break
+                response += chunk
+
+            return response.decode("utf-8").strip()
+    except ConnectionRefusedError:
+        raise ConnectionError(
+            f"Could not connect to socket server at {host}:{port}. "
+            "Make sure the YubiKey Daemon socket server is running."
+        ) from None
+    except TimeoutError:
+        raise TimeoutError(
+            f"Operation timed out after {timeout} seconds. "
+            "The server may be waiting for YubiKey touch."
+        ) from None
+
+
+def parse_response(response: str) -> tuple[bool, str]:
+    """Parse a server response.
+
+    Args:
+        response: Response string from server
+
+    Returns:
+        Tuple of (success: bool, data/error_message: str)
+    """
+    if response.startswith("OK"):
+        # Extract data after "OK "
+        data = response[3:] if len(response) > 3 else ""
+        return True, data
+    elif response.startswith("ERROR"):
+        # Extract error message after "ERROR "
+        error = response[6:] if len(response) > 6 else "Unknown error"
+        return False, error
+    else:
+        return False, f"Invalid response format: {response}"
+
+
+def list_accounts(host: str, port: int) -> list[str] | None:
+    """List all OATH accounts on YubiKey.
+
+    Args:
+        host: Server host
+        port: Server port
+
+    Returns:
+        List of account names or None on error
+    """
+    try:
+        print("\n📋 Listing accounts...")
+        response = send_command(host, port, "LIST_ACCOUNTS", timeout=10.0)
+        success, data = parse_response(response)
+
+        if success:
+            print(f"✅ Response: {response}")
+            if data:
+                accounts = data.split(",")
+                return accounts
+            else:
+                print("⚠️  No accounts found on YubiKey")
+                return []
+        else:
+            print(f"❌ Error: {data}")
+            return None
+    except (TimeoutError, ConnectionError) as e:
+        print(f"❌ Error: {e}")
+        return None
+
+
+def get_totp(host: str, port: int, account: str | None = None) -> str | None:
+    """Get TOTP code for an account.
+
+    Args:
+        host: Server host
+        port: Server port
+        account: Account name (optional, defaults to first account)
+
+    Returns:
+        TOTP code or None on error
+    """
+    try:
+        if account:
+            command = f"GET_TOTP {account}"
+            print(f"\n🔑 Generating TOTP for account: {account}...")
+        else:
+            command = "GET_TOTP"
+            print("\n🔑 Generating TOTP for default account...")
+
+        print("   (Touch your YubiKey if prompted)")
+
+        response = send_command(host, port, command, timeout=30.0)
+        success, data = parse_response(response)
+
+        if success:
+            print(f"✅ Response: {response}")
+            return data
+        else:
+            print(f"❌ Error: {data}")
+            return None
+    except (TimeoutError, ConnectionError) as e:
+        print(f"❌ Error: {e}")
+        return None
+
+
+def interactive_mode(host: str, port: int) -> int:
+    """Run in interactive mode allowing multiple commands.
+
+    Args:
+        host: Server host
+        port: Server port
+
+    Returns:
+        Exit code
+    """
+    print("\n" + "=" * 60)
+    print("Interactive Mode")
+    print("=" * 60)
+    print("Commands:")
+    print("  list              - List all accounts")
+    print("  get               - Get TOTP for first account")
+    print("  get <account>     - Get TOTP for specific account")
+    print("  quit              - Exit interactive mode")
+    print("=" * 60)
+
+    while True:
+        try:
+            user_input = input("\n> ").strip()
+
+            if not user_input:
+                continue
+
+            if user_input.lower() == "quit":
+                print("👋 Goodbye!")
+                return 0
+
+            if user_input.lower() == "list":
+                accounts = list_accounts(host, port)
+                if accounts:
+                    print(f"\nAccounts ({len(accounts)}):")
+                    for i, account in enumerate(accounts, 1):
+                        print(f"  {i}. {account}")
+
+            elif user_input.lower().startswith("get"):
+                parts = user_input.split(None, 1)
+                account_name: str | None = parts[1] if len(parts) > 1 else None
+                code = get_totp(host, port, account_name)
+                if code:
+                    print(f"\n✅ TOTP Code: {code}")
+
+            else:
+                print(f"❌ Unknown command: {user_input}")
+                print("   Type 'list', 'get [account]', or 'quit'")
+
+        except KeyboardInterrupt:
+            print("\n\n👋 Goodbye!")
+            return 0
+        except EOFError:
+            print("\n\n👋 Goodbye!")
+            return 0
+
+
+def main() -> int:
+    """Main function."""
+    parser = argparse.ArgumentParser(
+        description="Example client for YubiKey Daemon TCP Socket Server"
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Socket server host (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5001,
+        help="Socket server port (default: 5001)",
+    )
+    parser.add_argument(
+        "--account",
+        help="Specific account to get TOTP for (optional)",
+    )
+    parser.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        help="Run in interactive mode",
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("YubiKey Daemon Socket Server - Example Client")
+    print("=" * 60)
+    print(f"Server: {args.host}:{args.port}")
+    print("Protocol: Line-based TCP socket")
+
+    # Interactive mode
+    if args.interactive:
+        return interactive_mode(args.host, args.port)
+
+    # 1. List accounts
+    accounts = list_accounts(args.host, args.port)
+    if accounts is None:
+        return 1
+
+    if not accounts:
+        print("\n⚠️  No OATH accounts found on YubiKey")
+        return 1
+
+    print(f"\nFound {len(accounts)} account(s):")
+    for i, account in enumerate(accounts, 1):
+        print(f"  {i}. {account}")
+
+    # 2. Get TOTP
+    code = get_totp(args.host, args.port, args.account)
+
+    if code:
+        print("\n" + "=" * 60)
+        print("✅ SUCCESS")
+        print("=" * 60)
+        print(f"TOTP Code: {code}")
+        print("This code can be used for authentication")
+        print("=" * 60)
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/socket_server.py
+++ b/src/socket_server.py
@@ -1,0 +1,278 @@
+"""TCP socket server for low-latency TOTP requests.
+
+This module provides a simple line-based protocol for YubiKey TOTP operations
+over a TCP socket connection.
+
+Protocol:
+- Commands end with '\n'
+- Responses: 'OK <data>\n' or 'ERROR <message>\n'
+- Commands:
+  - GET_TOTP\n → OK 123456\n (returns first account's TOTP)
+  - GET_TOTP <account>\n → OK 123456\n (returns specific account's TOTP)
+  - LIST_ACCOUNTS\n → OK GitHub,AWS,Google\n (returns comma-separated list)
+"""
+
+import logging
+import socket
+import threading
+from typing import Any
+
+from src.yubikey import (
+    AccountNotFoundError,
+    DeviceNotFoundError,
+    DeviceRemovedError,
+    TouchTimeoutError,
+    YubiKeyInterface,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SocketServer:
+    """TCP socket server for YubiKey TOTP operations."""
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 5001,
+        yubikey_interface: YubiKeyInterface | None = None,
+    ) -> None:
+        """Initialize the socket server.
+
+        Args:
+            host: Host to bind to (default: 127.0.0.1)
+            port: Port to listen on (default: 5001)
+            yubikey_interface: YubiKey interface instance (optional)
+        """
+        self.host = host
+        self.port = port
+        self.yubikey = yubikey_interface or YubiKeyInterface()
+        self._server_socket: socket.socket | None = None
+        self._running = False
+        self._server_thread: threading.Thread | None = None
+        self._client_threads: list[threading.Thread] = []
+        self._lock = threading.Lock()
+        logger.info(f"Socket server initialized on {host}:{port}")
+
+    def start(self) -> None:
+        """Start the socket server in a background thread."""
+        if self._running:
+            logger.warning("Socket server is already running")
+            return
+
+        self._running = True
+        self._server_thread = threading.Thread(target=self._run_server, daemon=True)
+        self._server_thread.start()
+        logger.info(f"Socket server started on {self.host}:{self.port}")
+
+    def stop(self) -> None:
+        """Stop the socket server and close all connections."""
+        if not self._running:
+            logger.warning("Socket server is not running")
+            return
+
+        logger.info("Stopping socket server...")
+        self._running = False
+
+        # Close server socket to unblock accept()
+        if self._server_socket:
+            try:
+                self._server_socket.close()
+            except Exception as e:
+                logger.warning(f"Error closing server socket: {e}")
+            finally:
+                self._server_socket = None
+
+        # Wait for server thread to finish
+        if self._server_thread:
+            self._server_thread.join(timeout=2.0)
+            self._server_thread = None
+
+        # Wait for client threads to finish
+        with self._lock:
+            for thread in self._client_threads:
+                if thread.is_alive():
+                    thread.join(timeout=1.0)
+            self._client_threads.clear()
+
+        logger.info("Socket server stopped")
+
+    def _run_server(self) -> None:
+        """Main server loop that accepts client connections."""
+        try:
+            # Create server socket
+            self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._server_socket.bind((self.host, self.port))
+            self._server_socket.listen(5)
+
+            logger.info(f"Socket server listening on {self.host}:{self.port}")
+
+            while self._running:
+                try:
+                    # Accept client connection with timeout to allow graceful shutdown
+                    self._server_socket.settimeout(1.0)
+                    client_socket, client_address = self._server_socket.accept()
+                    logger.info(f"Client connected from {client_address}")
+
+                    # Handle client in separate thread
+                    client_thread = threading.Thread(
+                        target=self._handle_client,
+                        args=(client_socket, client_address),
+                        daemon=True,
+                    )
+                    client_thread.start()
+
+                    # Track client thread and clean up finished threads
+                    with self._lock:
+                        self._client_threads.append(client_thread)
+                        self._client_threads = [t for t in self._client_threads if t.is_alive()]
+
+                except TimeoutError:
+                    # Timeout is expected, allows us to check _running flag
+                    continue
+                except OSError as e:
+                    if self._running:
+                        logger.error(f"Socket error while accepting connections: {e}")
+                    break
+
+        except Exception as e:
+            logger.error(f"Server error: {e}")
+        finally:
+            if self._server_socket:
+                try:
+                    self._server_socket.close()
+                except Exception:
+                    pass
+                self._server_socket = None
+            logger.info("Server socket closed")
+
+    def _handle_client(self, client_socket: socket.socket, client_address: Any) -> None:
+        """Handle a client connection.
+
+        Args:
+            client_socket: Client socket connection
+            client_address: Client address tuple (host, port)
+        """
+        try:
+            with client_socket:
+                # Set receive timeout
+                client_socket.settimeout(30.0)
+
+                # Receive and process commands
+                buffer = ""
+                while self._running:
+                    try:
+                        # Receive data
+                        data = client_socket.recv(1024).decode("utf-8")
+                        if not data:
+                            # Client closed connection
+                            break
+
+                        buffer += data
+
+                        # Process complete commands (ending with \n)
+                        while "\n" in buffer:
+                            command, buffer = buffer.split("\n", 1)
+                            command = command.strip()
+
+                            if command:
+                                logger.debug(f"Received command from {client_address}: {command}")
+                                response = self._process_command(command)
+                                logger.debug(f"Sending response to {client_address}: {response}")
+                                client_socket.sendall((response + "\n").encode("utf-8"))
+
+                    except TimeoutError:
+                        logger.debug(f"Client {client_address} timeout")
+                        break
+                    except Exception as e:
+                        logger.error(f"Error handling client {client_address}: {e}")
+                        try:
+                            error_response = f"ERROR Internal server error: {e}"
+                            client_socket.sendall((error_response + "\n").encode("utf-8"))
+                        except Exception:
+                            pass
+                        break
+
+        except Exception as e:
+            logger.error(f"Client handler error for {client_address}: {e}")
+        finally:
+            logger.info(f"Client disconnected: {client_address}")
+
+    def _process_command(self, command: str) -> str:
+        """Process a client command and return response.
+
+        Args:
+            command: Command string (without trailing newline)
+
+        Returns:
+            Response string (without trailing newline)
+        """
+        try:
+            # Parse command
+            parts = command.split(None, 1)  # Split on first whitespace
+            if not parts:
+                return "ERROR Empty command"
+
+            cmd = parts[0].upper()
+
+            if cmd == "LIST_ACCOUNTS":
+                # List all accounts
+                accounts = self.yubikey.list_accounts()
+                if not accounts:
+                    return "OK"
+                return f"OK {','.join(accounts)}"
+
+            elif cmd == "GET_TOTP":
+                # Get TOTP for account or first account
+                account = parts[1] if len(parts) > 1 else None
+
+                if account:
+                    # Get TOTP for specific account
+                    code = self.yubikey.generate_totp(account)
+                    if isinstance(code, str):
+                        return f"OK {code}"
+                    else:
+                        return "ERROR Unexpected response type"
+                else:
+                    # Get TOTP for first account
+                    result = self.yubikey.generate_totp()
+                    if isinstance(result, dict):
+                        if not result:
+                            return "ERROR No accounts found"
+                        # Return first account's code
+                        first_code = next(iter(result.values()))
+                        return f"OK {first_code}"
+                    else:
+                        return "ERROR Unexpected response type"
+
+            else:
+                return f"ERROR Unknown command: {cmd}"
+
+        except DeviceNotFoundError as e:
+            logger.warning(f"YubiKey not found: {e}")
+            return f"ERROR YubiKey not connected: {e}"
+
+        except AccountNotFoundError as e:
+            logger.warning(f"Account not found: {e}")
+            return f"ERROR Account not found: {e}"
+
+        except TouchTimeoutError as e:
+            logger.warning(f"Touch timeout: {e}")
+            return f"ERROR Touch timeout: {e}"
+
+        except DeviceRemovedError as e:
+            logger.error(f"Device removed: {e}")
+            return f"ERROR Device error: {e}"
+
+        except Exception as e:
+            logger.error(f"Error processing command '{command}': {e}")
+            return f"ERROR Internal error: {e}"
+
+    def is_running(self) -> bool:
+        """Check if the server is running.
+
+        Returns:
+            bool: True if server is running, False otherwise
+        """
+        return self._running

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -1,0 +1,383 @@
+"""Unit tests for TCP socket server module."""
+
+import socket
+import time
+from collections.abc import Generator
+from unittest.mock import Mock
+
+import pytest
+
+from src.socket_server import SocketServer
+from src.yubikey import (
+    AccountNotFoundError,
+    DeviceNotFoundError,
+    DeviceRemovedError,
+    TouchTimeoutError,
+    YubiKeyInterface,
+)
+
+
+@pytest.fixture
+def mock_yubikey() -> Mock:
+    """Create a mock YubiKey interface."""
+    mock_yk = Mock(spec=YubiKeyInterface)
+    return mock_yk
+
+
+@pytest.fixture
+def socket_server(mock_yubikey: Mock) -> SocketServer:
+    """Create a socket server instance with mock YubiKey."""
+    # Use a random available port for testing
+    server = SocketServer(host="127.0.0.1", port=0, yubikey_interface=mock_yubikey)
+    return server
+
+
+@pytest.fixture
+def running_server(mock_yubikey: Mock) -> Generator[SocketServer, None, None]:
+    """Create and start a socket server instance."""
+    server = SocketServer(host="127.0.0.1", port=0, yubikey_interface=mock_yubikey)
+    server.start()
+
+    # Wait for server to start
+    time.sleep(0.1)
+
+    # Get the actual port the server bound to
+    # We need to access the socket to get the bound port
+    if server._server_socket:
+        server.port = server._server_socket.getsockname()[1]
+
+    yield server
+
+    server.stop()
+
+
+def send_command(host: str, port: int, command: str, timeout: float = 2.0) -> str:
+    """Helper function to send a command and receive response.
+
+    Args:
+        host: Server host
+        port: Server port
+        command: Command to send
+        timeout: Socket timeout in seconds
+
+    Returns:
+        Response string (without trailing newline)
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:
+        client_socket.settimeout(timeout)
+        client_socket.connect((host, port))
+        client_socket.sendall((command + "\n").encode("utf-8"))
+
+        # Receive response
+        response = b""
+        while b"\n" not in response:
+            chunk = client_socket.recv(1024)
+            if not chunk:
+                break
+            response += chunk
+
+        return response.decode("utf-8").strip()
+
+
+class TestSocketServer:
+    """Test cases for SocketServer class."""
+
+    def test_init(self, mock_yubikey: Mock) -> None:
+        """Test SocketServer initialization."""
+        server = SocketServer(host="127.0.0.1", port=5001, yubikey_interface=mock_yubikey)
+
+        assert server.host == "127.0.0.1"
+        assert server.port == 5001
+        assert server.yubikey == mock_yubikey
+        assert not server.is_running()
+
+    def test_init_default_yubikey(self) -> None:
+        """Test SocketServer initialization with default YubiKey interface."""
+        server = SocketServer(host="127.0.0.1", port=5001)
+
+        assert isinstance(server.yubikey, YubiKeyInterface)
+
+    def test_start_stop(self, socket_server: SocketServer) -> None:
+        """Test starting and stopping the server."""
+        assert not socket_server.is_running()
+
+        socket_server.start()
+        time.sleep(0.1)
+        assert socket_server.is_running()
+
+        socket_server.stop()
+        time.sleep(0.1)
+        assert not socket_server.is_running()
+
+    def test_start_already_running(self, running_server: SocketServer) -> None:
+        """Test starting a server that is already running."""
+        assert running_server.is_running()
+
+        # Starting again should not cause issues
+        running_server.start()
+        assert running_server.is_running()
+
+    def test_stop_not_running(self, socket_server: SocketServer) -> None:
+        """Test stopping a server that is not running."""
+        assert not socket_server.is_running()
+
+        # Stopping should not cause issues
+        socket_server.stop()
+        assert not socket_server.is_running()
+
+    def test_list_accounts_success(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test LIST_ACCOUNTS command with accounts."""
+        mock_yubikey.list_accounts.return_value = ["GitHub", "AWS", "Google"]
+
+        response = send_command(running_server.host, running_server.port, "LIST_ACCOUNTS")
+
+        assert response == "OK GitHub,AWS,Google"
+        mock_yubikey.list_accounts.assert_called_once()
+
+    def test_list_accounts_empty(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test LIST_ACCOUNTS command with no accounts."""
+        mock_yubikey.list_accounts.return_value = []
+
+        response = send_command(running_server.host, running_server.port, "LIST_ACCOUNTS")
+
+        assert response == "OK"
+        mock_yubikey.list_accounts.assert_called_once()
+
+    def test_list_accounts_device_not_found(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test LIST_ACCOUNTS command when device is not found."""
+        mock_yubikey.list_accounts.side_effect = DeviceNotFoundError("No YubiKey device found")
+
+        response = send_command(running_server.host, running_server.port, "LIST_ACCOUNTS")
+
+        assert response.startswith("ERROR YubiKey not connected:")
+
+    def test_get_totp_specific_account(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test GET_TOTP command for a specific account."""
+        mock_yubikey.generate_totp.return_value = "123456"
+
+        response = send_command(running_server.host, running_server.port, "GET_TOTP GitHub")
+
+        assert response == "OK 123456"
+        mock_yubikey.generate_totp.assert_called_once_with("GitHub")
+
+    def test_get_totp_first_account(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test GET_TOTP command without account (returns first)."""
+        mock_yubikey.generate_totp.return_value = {"GitHub": "123456", "AWS": "654321"}
+
+        response = send_command(running_server.host, running_server.port, "GET_TOTP")
+
+        assert response == "OK 123456"
+        mock_yubikey.generate_totp.assert_called_once_with()
+
+    def test_get_totp_no_accounts(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test GET_TOTP command when no accounts exist."""
+        mock_yubikey.generate_totp.return_value = {}
+
+        response = send_command(running_server.host, running_server.port, "GET_TOTP")
+
+        assert response == "ERROR No accounts found"
+
+    def test_get_totp_account_not_found(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test GET_TOTP command for non-existent account."""
+        mock_yubikey.generate_totp.side_effect = AccountNotFoundError("Account 'Unknown' not found")
+
+        response = send_command(running_server.host, running_server.port, "GET_TOTP Unknown")
+
+        assert response.startswith("ERROR Account not found:")
+
+    def test_get_totp_touch_timeout(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test GET_TOTP command when touch times out."""
+        mock_yubikey.generate_totp.side_effect = TouchTimeoutError("Touch timeout")
+
+        response = send_command(running_server.host, running_server.port, "GET_TOTP GitHub")
+
+        assert response.startswith("ERROR Touch timeout:")
+
+    def test_get_totp_device_removed(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test GET_TOTP command when device is removed during operation."""
+        mock_yubikey.generate_totp.side_effect = DeviceRemovedError("Device disconnected")
+
+        response = send_command(running_server.host, running_server.port, "GET_TOTP GitHub")
+
+        assert response.startswith("ERROR Device error:")
+
+    def test_unknown_command(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test handling of unknown command."""
+        response = send_command(running_server.host, running_server.port, "INVALID_COMMAND")
+
+        assert response.startswith("ERROR Unknown command:")
+
+    def test_empty_command(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test handling of empty command."""
+        # Empty command is skipped (no response), just verify server is still working
+        mock_yubikey.list_accounts.return_value = ["GitHub"]
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:
+            client_socket.settimeout(2.0)
+            client_socket.connect((running_server.host, running_server.port))
+
+            # Send empty command (only newline)
+            client_socket.sendall(b"\n")
+
+            # Send a real command to verify connection is still working
+            client_socket.sendall(b"LIST_ACCOUNTS\n")
+
+            # Should only receive response for the valid command
+            response = client_socket.recv(1024).decode("utf-8").strip()
+            assert response == "OK GitHub"
+
+    def test_case_insensitive_commands(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test that commands are case-insensitive."""
+        mock_yubikey.list_accounts.return_value = ["GitHub"]
+
+        # Test lowercase
+        response = send_command(running_server.host, running_server.port, "list_accounts")
+        assert response == "OK GitHub"
+
+        # Test mixed case
+        mock_yubikey.list_accounts.return_value = ["AWS"]
+        response = send_command(running_server.host, running_server.port, "List_Accounts")
+        assert response == "OK AWS"
+
+    def test_multiple_commands_same_connection(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test sending multiple commands on the same connection."""
+        mock_yubikey.list_accounts.return_value = ["GitHub", "AWS"]
+        mock_yubikey.generate_totp.return_value = "123456"
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:
+            client_socket.settimeout(2.0)
+            client_socket.connect((running_server.host, running_server.port))
+
+            # Send first command
+            client_socket.sendall(b"LIST_ACCOUNTS\n")
+            response1 = client_socket.recv(1024).decode("utf-8").strip()
+            assert response1 == "OK GitHub,AWS"
+
+            # Send second command
+            client_socket.sendall(b"GET_TOTP GitHub\n")
+            response2 = client_socket.recv(1024).decode("utf-8").strip()
+            assert response2 == "OK 123456"
+
+    def test_concurrent_connections(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test handling multiple concurrent client connections."""
+        mock_yubikey.list_accounts.return_value = ["GitHub"]
+
+        # Create multiple client connections
+        def client_task() -> str:
+            return send_command(running_server.host, running_server.port, "LIST_ACCOUNTS")
+
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(client_task) for _ in range(5)]
+            results = [f.result() for f in futures]
+
+        # All clients should get the same response
+        for result in results:
+            assert result == "OK GitHub"
+
+    def test_client_disconnect(self, running_server: SocketServer, mock_yubikey: Mock) -> None:
+        """Test server handles client disconnect gracefully."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:
+            client_socket.settimeout(2.0)
+            client_socket.connect((running_server.host, running_server.port))
+            # Close without sending anything
+
+        # Server should still be running
+        assert running_server.is_running()
+
+        # And should accept new connections
+        mock_yubikey.list_accounts.return_value = ["GitHub"]
+        response = send_command(running_server.host, running_server.port, "LIST_ACCOUNTS")
+        assert response == "OK GitHub"
+
+    def test_command_with_whitespace(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test commands with extra whitespace."""
+        mock_yubikey.generate_totp.return_value = "123456"
+
+        # Test command with leading/trailing spaces
+        response = send_command(running_server.host, running_server.port, "  GET_TOTP GitHub  ")
+
+        assert response == "OK 123456"
+
+    def test_account_name_with_spaces(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test GET_TOTP command with account name containing spaces."""
+        mock_yubikey.generate_totp.return_value = "123456"
+
+        response = send_command(
+            running_server.host, running_server.port, "GET_TOTP My Account Name"
+        )
+
+        assert response == "OK 123456"
+        mock_yubikey.generate_totp.assert_called_once_with("My Account Name")
+
+    def test_protocol_newline_handling(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test protocol correctly handles newline-delimited commands."""
+        mock_yubikey.list_accounts.return_value = ["GitHub"]
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:
+            client_socket.settimeout(2.0)
+            client_socket.connect((running_server.host, running_server.port))
+
+            # Send multiple commands in one packet
+            client_socket.sendall(b"LIST_ACCOUNTS\nLIST_ACCOUNTS\n")
+
+            # Should receive two responses
+            all_data = b""
+            # Read until we get both responses
+            for _ in range(5):  # Max 5 recv attempts
+                chunk = client_socket.recv(1024)
+                all_data += chunk
+                if all_data.count(b"\n") >= 2:
+                    break
+
+            response = all_data.decode("utf-8")
+            assert response.count("OK GitHub") == 2
+
+    def test_server_shutdown_closes_connections(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test that stopping the server closes active client connections."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:
+            client_socket.settimeout(2.0)
+            client_socket.connect((running_server.host, running_server.port))
+
+            # Stop server
+            running_server.stop()
+            time.sleep(0.2)
+
+            # Connection should be closed
+            with pytest.raises(socket.error):
+                client_socket.sendall(b"LIST_ACCOUNTS\n")
+                client_socket.recv(1024)
+
+    def test_get_totp_account_with_special_chars(
+        self, running_server: SocketServer, mock_yubikey: Mock
+    ) -> None:
+        """Test GET_TOTP with account names containing special characters."""
+        mock_yubikey.generate_totp.return_value = "123456"
+
+        response = send_command(
+            running_server.host, running_server.port, "GET_TOTP user@example.com"
+        )
+
+        assert response == "OK 123456"
+        mock_yubikey.generate_totp.assert_called_once_with("user@example.com")


### PR DESCRIPTION
## Summary

Implements a TCP socket server with a simple line-based protocol for YubiKey OATH-TOTP operations. This provides an alternative to the REST API for low-latency local communications.

## Changes

- **New Module:** `src/socket_server.py`
  - TCP socket server listening on configurable host:port (default 127.0.0.1:5001)
  - Simple line-based protocol with commands ending in `\n`
  - Supports `LIST_ACCOUNTS`, `GET_TOTP`, and `GET_TOTP <account>` commands
  - Handles concurrent connections with threading
  - Graceful shutdown and error handling

- **Comprehensive Testing:** `tests/test_socket_server.py`
  - 25 unit tests covering all functionality
  - Tests for concurrent connections, error handling, and protocol edge cases
  - All tests passing with proper mocking

- **Example Client:** `examples/socket_client.py`
  - Demonstrates how to use the socket protocol
  - Interactive mode for manual testing
  - Proper error handling and user feedback

## Protocol

```
Commands:
- LIST_ACCOUNTS\n → OK GitHub,AWS,Google\n
- GET_TOTP\n → OK 123456\n (returns first account's TOTP)
- GET_TOTP <account>\n → OK 123456\n (returns specific account's TOTP)

Responses:
- OK <data>\n (success with optional data)
- ERROR <message>\n (error with description)
```

## Test Plan

- [x] All unit tests pass (25/25)
- [x] Code passes linting (ruff)
- [x] Code passes type checking (mypy)
- [x] Example client script works correctly
- [x] Concurrent connections handled properly
- [x] Graceful shutdown implemented
- [x] Error handling verified

## Testing Instructions

### Start the socket server (in Python):
```python
from src.socket_server import SocketServer
from src.yubikey import YubiKeyInterface
from src.notifications import Notifier

notifier = Notifier()
yubikey = YubiKeyInterface(notifier=notifier)
server = SocketServer(host="127.0.0.1", port=5001, yubikey_interface=yubikey)
server.start()
```

### Test with example client:
```bash
# Interactive mode
python examples/socket_client.py --interactive

# Get TOTP for specific account
python examples/socket_client.py --account "GitHub"

# Test with netcat
echo "LIST_ACCOUNTS" | nc localhost 5001
echo "GET_TOTP GitHub" | nc localhost 5001
```

Closes #6