### PR TITLE
fix: update default ports from 5000/5001 to 5100/5101

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,11 @@ This is a Windows daemon written in Python that bridges YubiKey OATH-TOTP functi
 - Require physical touch for each TOTP generation
 
 ### Communication Protocols
-- **REST API**: Flask on port 5000 (default)
+- **REST API**: Flask on port 5100 (default)
   - JSON responses
   - Simple GET endpoints
   - Health check endpoint
-- **Socket Server**: TCP on port 5001 (default)
+- **Socket Server**: TCP on port 5101 (default)
   - Line-based protocol (commands end with `\n`)
   - Simple text responses: `OK <result>` or `ERROR <message>`
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ WSL 'cannot' directly access USB devices like YubiKeys due to USB passthrough li
 │                                                         │
 │  ┌──────────────┐         ┌─────────────────────────┐  │
 │  │   YubiKey    │◄────────┤    yk-daemon (Python)   │  │
-│  │   (USB)      │         │  - REST API (port 5000) │  │
-│  └──────────────┘         │  - Socket (port 5001)   │  │
+│  │   (USB)      │         │  - REST API (port 5100) │  │
+│  └──────────────┘         │  - Socket (port 5101)   │  │
 │                           │  - Notifications        │  │
 │                           └─────────┬───────────────┘  │
 │                                     │                   │
@@ -40,8 +40,8 @@ WSL 'cannot' directly access USB devices like YubiKeys due to USB passthrough li
 │                                     ▼                   │
 │  ┌──────────────────────────────────────────────────┐  │
 │  │  Linux Applications / Scripts                    │  │
-│  │  - curl http://127.0.0.1:5000/api/totp           │  │
-│  │  - netcat 127.0.0.1 5001                         │  │
+│  │  - curl http://127.0.0.1:5100/api/totp           │  │
+│  │  - netcat 127.0.0.1 5101                         │  │
 │  └──────────────────────────────────────────────────┘  │
 │                                                         │
 └─────────────────────────────────────────────────────────┘
@@ -98,7 +98,7 @@ poetry run python yk-daemon.py --remove
 
 ### REST API
 
-Base URL: `http://127.0.0.1:5000`
+Base URL: `http://127.0.0.1:5100`
 
 #### Get TOTP Code
 
@@ -165,7 +165,7 @@ GET /health
 
 ### Socket Protocol
 
-Connect to: `127.0.0.1:5001`
+Connect to: `127.0.0.1:5101`
 
 #### Get TOTP Code
 
@@ -218,12 +218,12 @@ Create a `config.json` file:
   "rest_api": {
     "enabled": true,
     "host": "127.0.0.1",
-    "port": 5000
+    "port": 5100
   },
   "socket": {
     "enabled": true,
     "host": "127.0.0.1",
-    "port": 5001
+    "port": 5101
   },
   "notifications": {
     "popup": true,
@@ -243,13 +243,13 @@ Create a `config.json` file:
 
 ```bash
 # Get TOTP code
-curl http://127.0.0.1:5000/api/totp
+curl http://127.0.0.1:5100/api/totp
 
 # Get TOTP for specific account
-curl http://127.0.0.1:5000/api/totp/GitHub
+curl http://127.0.0.1:5100/api/totp/GitHub
 
 # List accounts
-curl http://127.0.0.1:5000/api/accounts
+curl http://127.0.0.1:5100/api/accounts
 ```
 
 ### From WSL (Python)
@@ -257,7 +257,7 @@ curl http://127.0.0.1:5000/api/accounts
 ```python
 import requests
 
-response = requests.get('http://127.0.0.1:5000/api/totp')
+response = requests.get('http://127.0.0.1:5100/api/totp')
 data = response.json()
 print(f"TOTP Code: {data['totp']}")
 ```
@@ -266,14 +266,14 @@ print(f"TOTP Code: {data['totp']}")
 
 ```bash
 # Using netcat
-echo "GET_TOTP" | nc 127.0.0.1 5001
+echo "GET_TOTP" | nc 127.0.0.1 5101
 ```
 
 ```python
 import socket
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.connect(('127.0.0.1', 5001))
+sock.connect(('127.0.0.1', 5101))
 sock.send(b'GET_TOTP\n')
 response = sock.recv(1024).decode()
 print(response)  # OK 123456
@@ -382,8 +382,8 @@ ykman oath accounts list
 ### Cannot Connect from WSL
 
 1. Ensure Windows Firewall allows localhost connections
-2. Verify daemon is running: `curl http://127.0.0.1:5000/health` from Windows
-3. Check if ports are in use: `netstat -an | findstr "5000"`
+2. Verify daemon is running: `curl http://127.0.0.1:5100/health` from Windows
+3. Check if ports are in use: `netstat -an | findstr "5100"`
 
 ### Service Won't Start
 

--- a/config.example.json
+++ b/config.example.json
@@ -2,12 +2,12 @@
   "rest_api": {
     "enabled": true,
     "host": "127.0.0.1",
-    "port": 5000
+    "port": 5100
   },
   "socket": {
     "enabled": true,
     "host": "127.0.0.1",
-    "port": 5001
+    "port": 5101
   },
   "notifications": {
     "popup": true,

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,8 +6,8 @@ This directory contains example client scripts demonstrating how to interact wit
 
 The YubiKey daemon exposes two interfaces for client communication:
 
-1. **REST API** (HTTP/JSON) - Port 5000 (default)
-2. **Socket Server** (TCP/Text) - Port 5001 (default)
+1. **REST API** (HTTP/JSON) - Port 5100 (default)
+2. **Socket Server** (TCP/Text) - Port 5101 (default)
 
 Both interfaces provide the same functionality:
 - List OATH accounts on YubiKey
@@ -120,7 +120,7 @@ python get_totp.py
 
 ### REST API Endpoints
 
-**Base URL:** `http://127.0.0.1:5000`
+**Base URL:** `http://127.0.0.1:5100`
 
 | Endpoint | Method | Description | Response |
 |----------|--------|-------------|----------|
@@ -132,21 +132,21 @@ python get_totp.py
 **Example requests:**
 ```bash
 # Health check
-curl http://127.0.0.1:5000/health
+curl http://127.0.0.1:5100/health
 
 # List accounts
-curl http://127.0.0.1:5000/api/accounts
+curl http://127.0.0.1:5100/api/accounts
 
 # Get default TOTP
-curl http://127.0.0.1:5000/api/totp
+curl http://127.0.0.1:5100/api/totp
 
 # Get specific account TOTP
-curl http://127.0.0.1:5000/api/totp/GitHub
+curl http://127.0.0.1:5100/api/totp/GitHub
 ```
 
 ### Socket Protocol
 
-**Connection:** TCP to `127.0.0.1:5001`
+**Connection:** TCP to `127.0.0.1:5101`
 
 **Protocol:** Line-based, commands end with `\n`
 
@@ -163,13 +163,13 @@ curl http://127.0.0.1:5000/api/totp/GitHub
 **Example using netcat:**
 ```bash
 # List accounts
-echo "LIST_ACCOUNTS" | nc 127.0.0.1 5001
+echo "LIST_ACCOUNTS" | nc 127.0.0.1 5101
 
 # Get default TOTP
-echo "GET_TOTP" | nc 127.0.0.1 5001
+echo "GET_TOTP" | nc 127.0.0.1 5101
 
 # Get specific account TOTP
-echo "GET_TOTP GitHub" | nc 127.0.0.1 5001
+echo "GET_TOTP GitHub" | nc 127.0.0.1 5101
 ```
 
 ## Usage from WSL
@@ -270,8 +270,8 @@ ERROR Touch timeout - please touch YubiKey
 ps aux | grep -E "(rest_api|socket_server)"
 
 # Test network connectivity
-nc -zv 127.0.0.1 5000  # REST API
-nc -zv 127.0.0.1 5001  # Socket server
+nc -zv 127.0.0.1 5100  # REST API
+nc -zv 127.0.0.1 5101  # Socket server
 
 # Check YubiKey detection
 ykman oath accounts list

--- a/examples/bash_client.sh
+++ b/examples/bash_client.sh
@@ -5,8 +5,8 @@
 # using standard command-line tools like curl and netcat (nc).
 #
 # Protocol Information:
-# - REST API: HTTP/JSON on port 5000 (default)
-# - Socket Server: Line-based TCP on port 5001 (default)
+# - REST API: HTTP/JSON on port 5100 (default)
+# - Socket Server: Line-based TCP on port 5101 (default)
 # - Both services bind to localhost (127.0.0.1)
 # - YubiKey touch required for TOTP generation
 #
@@ -15,8 +15,8 @@
 #
 # Options:
 #     --host HOST         API/socket host (default: 127.0.0.1)
-#     --rest-port PORT    REST API port (default: 5000)
-#     --socket-port PORT  Socket server port (default: 5001)
+#     --rest-port PORT    REST API port (default: 5100)
+#     --socket-port PORT  Socket server port (default: 5101)
 #     --account ACCOUNT   Specific account name for TOTP
 #     --rest-only         Only test REST API
 #     --socket-only       Only test socket server
@@ -34,8 +34,8 @@ set -euo pipefail
 
 # Default configuration
 HOST="127.0.0.1"
-REST_PORT="5000"
-SOCKET_PORT="5001"
+REST_PORT="5100"
+SOCKET_PORT="5101"
 ACCOUNT=""
 REST_ONLY=false
 SOCKET_ONLY=false
@@ -393,8 +393,8 @@ show_help() {
     echo
     echo "Options:"
     echo "  --host HOST         API/socket host (default: 127.0.0.1)"
-    echo "  --rest-port PORT    REST API port (default: 5000)"
-    echo "  --socket-port PORT  Socket server port (default: 5001)"
+    echo "  --rest-port PORT    REST API port (default: 5100)"
+    echo "  --socket-port PORT  Socket server port (default: 5101)"
     echo "  --account ACCOUNT   Specific account name for TOTP (optional)"
     echo "  --rest-only         Only test REST API"
     echo "  --socket-only       Only test socket server"

--- a/examples/rest_api_client.py
+++ b/examples/rest_api_client.py
@@ -149,8 +149,8 @@ def main() -> int:
     parser.add_argument(
         "--port",
         type=int,
-        default=5000,
-        help="API port (default: 5000)",
+        default=5100,
+        help="API port (default: 5100)",
     )
     parser.add_argument(
         "--account",

--- a/examples/socket_client.py
+++ b/examples/socket_client.py
@@ -221,8 +221,8 @@ def main() -> int:
     parser.add_argument(
         "--port",
         type=int,
-        default=5001,
-        help="Socket server port (default: 5001)",
+        default=5101,
+        help="Socket server port (default: 5101)",
     )
     parser.add_argument(
         "--account",

--- a/src/yk_daemon/config.py
+++ b/src/yk_daemon/config.py
@@ -7,8 +7,8 @@ This module handles loading and validating configuration from:
 
 Environment variables follow the pattern: YK_DAEMON_<SECTION>_<KEY>
 Examples:
-- YK_DAEMON_REST_API_PORT=5000
-- YK_DAEMON_SOCKET_PORT=5001
+- YK_DAEMON_REST_API_PORT=5100
+- YK_DAEMON_SOCKET_PORT=5101
 - YK_DAEMON_LOGGING_LEVEL=DEBUG
 """
 
@@ -34,7 +34,7 @@ class RestApiConfig:
 
     enabled: bool = True
     host: str = "127.0.0.1"
-    port: int = 5000
+    port: int = 5100
 
     def validate(self) -> None:
         """Validate REST API configuration."""
@@ -59,7 +59,7 @@ class SocketConfig:
 
     enabled: bool = True
     host: str = "127.0.0.1"
-    port: int = 5001
+    port: int = 5101
 
     def validate(self) -> None:
         """Validate socket configuration."""
@@ -217,8 +217,8 @@ def _load_env_overrides() -> dict[str, Any]:
     Environment variables follow the pattern: YK_DAEMON_<SECTION>_<KEY>
     Examples:
         YK_DAEMON_REST_API_ENABLED=false
-        YK_DAEMON_REST_API_PORT=5000
-        YK_DAEMON_SOCKET_PORT=5001
+        YK_DAEMON_REST_API_PORT=5100
+        YK_DAEMON_SOCKET_PORT=5101
         YK_DAEMON_LOGGING_LEVEL=DEBUG
 
     Returns:

--- a/src/yk_daemon/socket_server.py
+++ b/src/yk_daemon/socket_server.py
@@ -34,14 +34,14 @@ class SocketServer:
     def __init__(
         self,
         host: str = "127.0.0.1",
-        port: int = 5001,
+        port: int = 5101,
         yubikey_interface: YubiKeyInterface | None = None,
     ) -> None:
         """Initialize the socket server.
 
         Args:
             host: Host to bind to (default: 127.0.0.1)
-            port: Port to listen on (default: 5001)
+            port: Port to listen on (default: 5101)
             yubikey_interface: YubiKey interface instance (optional)
         """
         self.host = host

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,7 @@ class TestRestApiConfig:
         config = RestApiConfig()
         assert config.enabled is True
         assert config.host == "127.0.0.1"
-        assert config.port == 5000
+        assert config.port == 5100
 
     def test_custom_values(self) -> None:
         """Test custom configuration values."""
@@ -57,7 +57,7 @@ class TestRestApiConfig:
     def test_validate_invalid_port_type(self) -> None:
         """Test validation fails for invalid port type."""
         config = RestApiConfig()
-        config.port = "5000"  # type: ignore
+        config.port = "5100"  # type: ignore
         with pytest.raises(ConfigurationError, match="rest_api.port must be an integer"):
             config.validate()
 
@@ -88,7 +88,7 @@ class TestSocketConfig:
         config = SocketConfig()
         assert config.enabled is True
         assert config.host == "127.0.0.1"
-        assert config.port == 5001
+        assert config.port == 5101
 
     def test_custom_values(self) -> None:
         """Test custom configuration values."""
@@ -211,8 +211,8 @@ class TestConfig:
     def test_validate_port_conflict(self) -> None:
         """Test validation fails when REST API and socket use same port."""
         config = Config()
-        config.rest_api.port = 5000
-        config.socket.port = 5000
+        config.rest_api.port = 5100
+        config.socket.port = 5100
         with pytest.raises(ConfigurationError, match="cannot use the same host:port combination"):
             config.validate()
 
@@ -229,8 +229,8 @@ class TestConfig:
     def test_validate_allows_different_ports(self) -> None:
         """Test validation passes when ports are different."""
         config = Config()
-        config.rest_api.port = 5000
-        config.socket.port = 5001
+        config.rest_api.port = 5100
+        config.socket.port = 5101
         config.validate()  # Should not raise
 
 
@@ -243,9 +243,9 @@ class TestLoadConfig:
         config = load_config("nonexistent.json")
 
         assert config.rest_api.enabled is True
-        assert config.rest_api.port == 5000
+        assert config.rest_api.port == 5100
         assert config.socket.enabled is True
-        assert config.socket.port == 5001
+        assert config.socket.port == 5101
 
     def test_load_config_from_file(self, tmp_path: Path) -> None:
         """Test loading config from JSON file."""
@@ -286,7 +286,7 @@ class TestLoadConfig:
     def test_load_config_with_env_overrides(self, tmp_path: Path) -> None:
         """Test loading config with environment variable overrides."""
         config_file = tmp_path / "config.json"
-        config_data = {"rest_api": {"port": 5000}}
+        config_data = {"rest_api": {"port": 5100}}
         config_file.write_text(json.dumps(config_data))
 
         os.chdir(tmp_path)
@@ -381,12 +381,12 @@ class TestLoadConfig:
         # Defaults preserved
         assert config.rest_api.enabled is True
         assert config.rest_api.host == "127.0.0.1"
-        assert config.socket.port == 5001
+        assert config.socket.port == 5101
 
     def test_load_config_env_priority_over_file(self, tmp_path: Path) -> None:
         """Test that environment variables have priority over file."""
         config_file = tmp_path / "config.json"
-        config_data = {"rest_api": {"port": 5000}}
+        config_data = {"rest_api": {"port": 5100}}
         config_file.write_text(json.dumps(config_data))
 
         os.chdir(tmp_path)
@@ -411,6 +411,6 @@ class TestLoadConfig:
             config = load_config("nonexistent.json")
 
         # Should still load with defaults
-        assert config.rest_api.port == 5000
+        assert config.rest_api.port == 5100
         # Should log warnings
         assert "Ignoring" in caplog.text or "Unknown" in caplog.text

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -83,7 +83,7 @@ class TestServerManagement:
 
             mock_run_rest.side_effect = mock_server
 
-            config = Config(rest_api=RestApiConfig(host="127.0.0.1", port=5000))
+            config = Config(rest_api=RestApiConfig(host="127.0.0.1", port=5100))
             yubikey = MagicMock()
 
             # Reset shutdown event
@@ -109,7 +109,7 @@ class TestServerManagement:
             mock_server = MagicMock()
             mock_socket_class.return_value = mock_server
 
-            config = Config(socket=SocketConfig(host="127.0.0.1", port=5001))
+            config = Config(socket=SocketConfig(host="127.0.0.1", port=5101))
             yubikey = MagicMock()
 
             # Start server
@@ -117,7 +117,7 @@ class TestServerManagement:
 
             # Check server was created and started
             mock_socket_class.assert_called_once_with(
-                host="127.0.0.1", port=5001, yubikey_interface=yubikey
+                host="127.0.0.1", port=5101, yubikey_interface=yubikey
             )
             mock_server.start.assert_called_once()
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -20,7 +20,7 @@ from yk_daemon.yubikey import (
 @pytest.fixture
 def rest_api_config() -> RestApiConfig:
     """Create a REST API configuration for testing."""
-    return RestApiConfig(enabled=True, host="127.0.0.1", port=5000)
+    return RestApiConfig(enabled=True, host="127.0.0.1", port=5100)
 
 
 @pytest.fixture

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -84,16 +84,16 @@ class TestSocketServer:
 
     def test_init(self, mock_yubikey: Mock) -> None:
         """Test SocketServer initialization."""
-        server = SocketServer(host="127.0.0.1", port=5001, yubikey_interface=mock_yubikey)
+        server = SocketServer(host="127.0.0.1", port=5101, yubikey_interface=mock_yubikey)
 
         assert server.host == "127.0.0.1"
-        assert server.port == 5001
+        assert server.port == 5101
         assert server.yubikey == mock_yubikey
         assert not server.is_running()
 
     def test_init_default_yubikey(self) -> None:
         """Test SocketServer initialization with default YubiKey interface."""
-        server = SocketServer(host="127.0.0.1", port=5001)
+        server = SocketServer(host="127.0.0.1", port=5101)
 
         assert isinstance(server.yubikey, YubiKeyInterface)
 


### PR DESCRIPTION
## Summary

This PR updates the default ports to avoid conflicts with other services commonly running on ports 5000 and 5001.

### Changes
- **REST API port**: 5000 → 5100
- **Socket server port**: 5001 → 5101

### Files Updated
- `src/yk_daemon/config.py` - Updated default port values
- `src/yk_daemon/socket_server.py` - Updated default port parameter
- `config.example.json` - Updated example configuration
- `README.md` - Updated all port references in documentation
- `CLAUDE.md` - Updated project instructions
- `examples/README.md` - Updated examples documentation
- `examples/bash_client.sh` - Updated default ports
- `examples/rest_api_client.py` - Updated default port
- `examples/socket_client.py` - Updated default port
- All test files updated to use new default ports

## Test plan
- [x] All 164 tests passing
- [x] Linting passed (ruff)
- [x] Type checking passed (mypy)
- [x] Pre-commit hooks passed
- [x] Verified port changes in all source files, tests, documentation, and examples

## Breaking Change Note
This is technically a breaking change for users who rely on the default ports. However, since the ports are configurable via `config.json` or environment variables, users can easily maintain their current configuration if needed.

Closes #22